### PR TITLE
Add context param for function callings

### DIFF
--- a/lib/Redis/Jet.xs
+++ b/lib/Redis/Jet.xs
@@ -476,7 +476,7 @@ _destroy(self)
     if ( self->read_buf_len != 0 ) {
       Safefree(self->read_buf);
     }
-    disconnect_socket(self);
+    disconnect_socket(aTHX_ self);
     SvREFCNT_dec((SV*)self->server);
     SvREFCNT_dec((SV*)self->bucket);
     Safefree(self);
@@ -589,7 +589,7 @@ command(self,...)
       }
       if ( self->fileno == 0 ) {
         /* connection error */
-        disconnect_socket(self);
+        disconnect_socket(aTHX_ self);
         if ( self->reconnect_attempts > 0 && self->reconnect_attempts > connect_retry ) {
           connect_retry++;
           usleep(self->reconnect_delay*1000000); // micro-sec
@@ -724,7 +724,7 @@ command(self,...)
 
     /* request error */
     if (ret <= 0) {
-      disconnect_socket(self);
+      disconnect_socket(aTHX_ self);
       if ( ret == 0 && self->reconnect_attempts > 0 && self->reconnect_attempts > connect_retry ) {
         connect_retry++;
         usleep(self->reconnect_delay*1000000);  // micro-sec
@@ -771,7 +771,7 @@ command(self,...)
       ret = _read_timeout(self->fileno, self->io_timeout, &self->read_buf[readed], READ_MAX);
       if ( ret <= 0 ) {
         /* timeout or error */
-        disconnect_socket(self);
+        disconnect_socket(aTHX_ self);
         if ( PIPELINE(ix) ) {
           for (i=parsed_response; i<pipeline_len; i++) {
             data_av = newAV();
@@ -796,7 +796,7 @@ command(self,...)
                                             readed - parse_offset, data_sv, error_sv, self->utf8);
         if ( parse_result == -1 ) {
           /* corruption */
-          disconnect_socket(self);
+          disconnect_socket(aTHX_ self);
           if ( PIPELINE(ix) ) {
             for (i=parsed_response; i<pipeline_len; i++) {
               data_av = newAV();


### PR DESCRIPTION
I got following error when building.

```
% ./Build
Building Redis-Jet
cc -I/home/syohei/.plenv/versions/5.22.0/lib/perl5/5.22.0/x86_64-linux-thread-multi/CORE -DVERSION="0.02" -DXS_VERSION="0.02" -fPIC -c -D_REENTRANT -D_GNU_SOURCE -fwrapv -fno-strict-aliasing -pipe -fstack-protector -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -O2 -g -o lib/Redis/Jet.o lib/Redis/Jet.c
lib/Redis/Jet.xs: In function ‘XS_Redis__Jet__destroy’:
lib/Redis/Jet.xs:479:5: warning: passing argument 1 of ‘disconnect_socket’ from incompatible pointer type [enabled by default]
     disconnect_socket(self);
     ^
lib/Redis/Jet.xs:361:1: note: expected ‘struct PerlInterpreter *’ but argument is of type ‘struct Redis_Jet *’
 disconnect_socket (pTHX_ Redis_Jet * self) {
 ^
lib/Redis/Jet.xs:479:5: error: too few arguments to function ‘disconnect_socket’
     disconnect_socket(self);
     ^
lib/Redis/Jet.xs:361:1: note: declared here
 disconnect_socket (pTHX_ Redis_Jet * self) {
 ^
lib/Redis/Jet.xs: In function ‘XS_Redis__Jet_command’:
lib/Redis/Jet.xs:592:9: warning: passing argument 1 of ‘disconnect_socket’ from incompatible pointer type [enabled by default]
         disconnect_socket(self);
         ^
lib/Redis/Jet.xs:361:1: note: expected ‘struct PerlInterpreter *’ but argument is of type ‘struct Redis_Jet *’
 disconnect_socket (pTHX_ Redis_Jet * self) {
 ^
lib/Redis/Jet.xs:592:9: error: too few arguments to function ‘disconnect_socket’
         disconnect_socket(self);
         ^
lib/Redis/Jet.xs:361:1: note: declared here
 disconnect_socket (pTHX_ Redis_Jet * self) {
 ^
lib/Redis/Jet.xs:727:7: warning: passing argument 1 of ‘disconnect_socket’ from incompatible pointer type [enabled by default]
       disconnect_socket(self);
       ^
lib/Redis/Jet.xs:361:1: note: expected ‘struct PerlInterpreter *’ but argument is of type ‘struct Redis_Jet *’
 disconnect_socket (pTHX_ Redis_Jet * self) {
 ^
lib/Redis/Jet.xs:727:7: error: too few arguments to function ‘disconnect_socket’
       disconnect_socket(self);
       ^
lib/Redis/Jet.xs:361:1: note: declared here
 disconnect_socket (pTHX_ Redis_Jet * self) {
 ^
lib/Redis/Jet.xs:774:9: warning: passing argument 1 of ‘disconnect_socket’ from incompatible pointer type [enabled by default]
         disconnect_socket(self);
         ^
lib/Redis/Jet.xs:361:1: note: expected ‘struct PerlInterpreter *’ but argument is of type ‘struct Redis_Jet *’
 disconnect_socket (pTHX_ Redis_Jet * self) {
 ^
lib/Redis/Jet.xs:774:9: error: too few arguments to function ‘disconnect_socket’
         disconnect_socket(self);
         ^
lib/Redis/Jet.xs:361:1: note: declared here
 disconnect_socket (pTHX_ Redis_Jet * self) {
 ^
lib/Redis/Jet.xs:799:11: warning: passing argument 1 of ‘disconnect_socket’ from incompatible pointer type [enabled by default]
           disconnect_socket(self);
           ^
lib/Redis/Jet.xs:361:1: note: expected ‘struct PerlInterpreter *’ but argument is of type ‘struct Redis_Jet *’
 disconnect_socket (pTHX_ Redis_Jet * self) {
 ^
lib/Redis/Jet.xs:799:11: error: too few arguments to function ‘disconnect_socket’
           disconnect_socket(self);
           ^
lib/Redis/Jet.xs:361:1: note: declared here
 disconnect_socket (pTHX_ Redis_Jet * self) {
 ^
error building lib/Redis/Jet.o from 'lib/Redis/Jet.c' at /home/syohei/.plenv/versions/5.22.0/lib/perl5/site_perl/5.22.0/ExtUtils/CBuilder/Base.pm line 173.
```
